### PR TITLE
chore: Add Python 3.12 as a dependnecy

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -10,5 +10,6 @@ platforms = ["linux-64", "osx-arm64", "osx-64", "win-64"]
 example = "python analysis.py"
 
 [dependencies]
+python = "3.12.*"
 scipy = ">=1.14.0,<2"
 matplotlib = ">=3.9.1,<4"


### PR DESCRIPTION
* Explicitly add Python 3.12 to pixi.toml.